### PR TITLE
Target .NET Standard 2.0 #24

### DIFF
--- a/examples/PermitOnboardingApp/PermitOnboardingApp.csproj
+++ b/examples/PermitOnboardingApp/PermitOnboardingApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/permit/PermitSDK.csproj
+++ b/src/permit/PermitSDK.csproj
@@ -3,8 +3,9 @@
   <PropertyGroup>
     <RootNamespace>PermitSDK</RootNamespace>
     <AssemblyName>Permit</AssemblyName>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>disable</Nullable>
+    <LangVersion>latest</LangVersion>
     <Configurations>Release;Debug</Configurations>
   </PropertyGroup>
 <PropertyGroup>


### PR DESCRIPTION
In order to support the SDK on .NET Framework 4.8.1 (and other non-.NET Core or later targets) we need .NET Standard 2.0. This adds a second target framework of .NET Standard 2.0.

This also resolves the example targeting an EOL framework.

Resolves #24 